### PR TITLE
Feature/add custom tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library provides TeX-Hyphenation in PHP.
 
 This package has the following requirements:
 
-* PHP-Version >= 5.3
+* PHP-Version >= 5.6
 * Multibyte-Extension loaded
 * Input has to be UTF8-encoded.
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require" : {
-        "php" : "^5.3||^7.0",
+        "php" : "^5.6||^7.0",
         "ext-mbstring" : "*"
     },
     "require-dev" : {

--- a/src/Filter/NonStandardFilter.php
+++ b/src/Filter/NonStandardFilter.php
@@ -68,7 +68,7 @@ class NonStandardFilter extends Filter
                 continue;
             }
             $string = $token->getFilteredContent();
-            $pattern = $token->getMergedPattern();
+            $pattern = $token->getMergedPattern($this->_options->getQuality());
             $length  = $token->length();
             $result = array();
             for ($i = 1; $i <= $length; $i++) {

--- a/src/Filter/SimpleFilter.php
+++ b/src/Filter/SimpleFilter.php
@@ -68,16 +68,17 @@ class SimpleFilter extends Filter
                 continue;
             }
             $string = $token->getFilteredContent();
-            $pattern = $token->getMergedPattern();
+            $pattern = $token->getMergedPattern($this->_options->getQuality());
             $length  = $token->length();
             $lastOne = 0;
             $result = array();
+
             for ($i = 1; $i <= $length; $i++) {
                 $currPattern = mb_substr($pattern, $i, 1);
                 if ($i < $this->_options->getLeftMin()) {
                     continue;
                 }
-                if ($i > $length - $this->_options->getRightMin()) {
+                if ($i > ($length - $this->_options->getRightMin())) {
                     continue;
                 }
                 if (0 == $currPattern) {

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -362,13 +362,12 @@ final class Hyphenator
         $tokens = $this->_tokenizers->tokenize($string);
         $tokens = $this->getHyphenationPattern($tokens);
         $tokens = $this->filter($tokens);
-        if (1 === sizeof($tokens) && 1 === $this->getFilters()->count()) {
+        if (1 === count($tokens) && 1 === $this->getFilters()->count()) {
             $tokens->rewind();
-            $return = $tokens->current()->getHyphenatedContent();
-        } else {
-            $return = $this->getFilters()->concatenate($tokens);
+            return $tokens->current()->getHyphenatedContent();
         }
-        return $return;
+
+        return $this->getFilters()->concatenate($tokens);
     }
 
     /**
@@ -391,7 +390,6 @@ final class Hyphenator
             if ($minWordLength > $token->length()) {
                 continue;
             }
-            $time = microtime(true);
             $this->getPatternForToken($token);
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -274,6 +274,16 @@ class Options
     }
 
     /**
+     * Get the hyphenation-quality
+     *
+     * @return int
+     */
+    public function getQuality()
+    {
+        return $this->_quality;
+    }
+
+    /**
      * Get the minimum Length of a word to be hyphenated
      *
      * @return int

--- a/src/Tokenizer/ExcludedWordToken.php
+++ b/src/Tokenizer/ExcludedWordToken.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2008-2011 Andreas Heigl<andreas@heigl.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category   Hyphenation
+ * @package    Org_Heigl_Hyphenator
+ * @subpackage Tokenizer
+ * @author     Andreas Heigl <andreas@heigl.org>
+ * @copyright  2008-2011 Andreas Heigl<andreas@heigl.org>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version    2.0.beta
+ * @link       http://github.com/heiglandreas/Hyphenator
+ * @since      11.11.2011
+ */
+
+namespace Org\Heigl\Hyphenator\Tokenizer;
+
+/**
+ * This Class describes a Token represeonting something that is not a word.
+ *
+ * @category   Hyphenation
+ * @package    Org_Heigl_Hyphenator
+ * @subpackage Tokenizer
+ * @author     Andreas Heigl <andreas@heigl.org>
+ * @copyright  2008-2011 Andreas Heigl<andreas@heigl.org>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version    2.0.beta
+ * @link       http://github.com/heiglandreas/Hyphenator
+ * @since      04.11.2011
+ */
+class ExcludedWordToken extends Token
+{
+    //
+}

--- a/src/Tokenizer/PunctuationTokenizer.php
+++ b/src/Tokenizer/PunctuationTokenizer.php
@@ -112,10 +112,7 @@ class PunctuationTokenizer implements Tokenizer
             // Tokenize a TokenRegistry
             $f = clone($input);
             foreach ($input as $token) {
-                if ($token instanceof WhitespaceToken) {
-                    continue;
-                }
-                if ($token instanceof NonWordToken) {
+                if (! $token instanceof WordToken) {
                     continue;
                 }
                 $newTokens = $this->_tokenize($token->get());

--- a/tests/HyphenatorFeatureTest.php
+++ b/tests/HyphenatorFeatureTest.php
@@ -57,20 +57,57 @@ class HyphenatorFeatureTest extends \PHPUnit_Framework_TestCase
           ->setDefaultLocale($language)
           ->setRightMin(2)
           ->setLeftMin(2)
-          ->setWordMin(5)
+          ->setWordMin(4)
           ->setFilters('NonStandard')
-          ->setTokenizers('Whitespace', 'Punctuation');
+          ->setTokenizers('Whitespace, Punctuation');
         
         $h = new h\Hyphenator();
         $h->setOptions($o);
         $this->assertEquals($expected, $h->hyphenate($word));
     }
-    
+
     public function hyphenationOfSingleWordWithArrayOutputProvider()
     {
-        return array(
-                array('donaudampfschifffahrt', 'de_DE', array('do-naudampfschifffahrt', 'donau-dampfschifffahrt', 'donaudampf-schifffahrt', 'donaudampfschiff-fahrt')),
-//                array('altbaucharme', 'de_DE', array('alt-baucharme', 'altbau-charme')),
-            );
+        return [
+            ['donaudampfschifffahrt', 'de_DE', ['do-naudampfschifffahrt', 'donau-dampfschifffahrt', 'donaudampf-schifffahrt', 'donaudampfschiff-fahrt']],
+//            ['altbaucharme', 'de_DE', array['alt-baucharme', 'altbau-charme']],
+            ['otto', 'de_DE', ['ot-to']],
+
+        ];
+    }
+
+
+    /**
+     * @dataProvider hyphenationOfSingleWordWithDefaultOutputProvider
+     */
+    public function testHyphenationOfSingleWordWithDefaultOutput($word, $language, $expected, $quality = 9)
+    {
+        $o = new h\Options();
+        $o->setHyphen('^')
+          ->setDefaultLocale($language)
+          ->setRightMin(2)
+          ->setLeftMin(2)
+          ->setWordMin(4)
+          ->setFilters('Simple')
+          ->setQuality($quality)
+          ->setTokenizers('Whitespace, Punctuation');
+
+        $h = new h\Hyphenator();
+        $h->setOptions($o);
+
+        $this->assertEquals($expected, $h->hyphenate($word));
+    }
+
+    public function hyphenationOfSingleWordWithDefaultOutputProvider()
+    {
+        return [
+            ['donaudampfschifffahrt ', 'de_DE', 'do^nau^dampf^schiff^fahrt '],
+//            ['altbaucharme', 'de_DE', 'alt-bau-charme'],
+            ['otto ', 'de_DE', 'ot^to '],
+            ['daniel ', 'de_DE', 'da^niel '],
+            ['aussichtsturm ', 'de_DE', 'aus^sichtsturm '], // Sturm will not be hyphenated…
+            ['aussichtsturm ', 'de_DE', 'aus^sicht^sturm ', h\Hyphenator::QUALITY_NORMAL], // Sturm will not be hyphenated…
+            ['urinstinkt ', 'de_DE', 'ur^instinkt ', h\Hyphenator::QUALITY_HIGHEST], // Sturm will not be hyphenated…
+        ];
     }
 }

--- a/tests/Tokenizer/CustomHyphenationTokenizerTest.php
+++ b/tests/Tokenizer/CustomHyphenationTokenizerTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright (c) 2008-2011 Andreas Heigl<andreas@heigl.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category  Hyphenator
+ * @package   Org\Heigl\Hyphenator
+ * @author    Andreas Heigl <andreas@heigl.org>
+ * @copyright 2008-2011 Andreas Heigl<andreas@heigl.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   2.0.1
+ * @since     02.11.2011
+ */
+
+namespace Org\Heigl\HyphenatorTest\Tokenizer;
+
+use Org\Heigl\Hyphenator\Options;
+use \Org\Heigl\Hyphenator\Tokenizer as t;
+use Mockery as M;
+
+/**
+ * This class tests the functionality of the class PunctuationTokenizer
+ *
+ * @category  Hyphenator
+ * @package   Org\Heigl\Hyphenator
+ * @author    Andreas Heigl <andreas@heigl.org>
+ * @copyright 2008-2011 Andreas Heigl<andreas@heigl.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   2.0.1
+ * @since     02.11.2011
+ */
+class CustomHyphenationTokenizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTokenizingString()
+    {
+        $options = M::mock(Options::class);
+        $options->shouldReceive('getNoHyphenateString')->andReturn('==');
+        $options->shouldReceive('getCustomHyphen')->andReturn('--');
+        $options->shouldReceive('getHyphen')->andReturn('^^');
+
+
+        $tReg = new t\TokenRegistry();
+        $tReg->add(new t\WordToken('Das ist '))
+             ->add(new t\ExcludedWordToken('nicht'))
+             ->add(new t\WordToken(' getrennt und das hat eine '))
+             ->add(new t\ExcludedWordToken('kunden^^spezifische'))
+             ->add(new t\WordToken(' Trennung!'));
+
+        $tokenizer = new t\CustomHyphenationTokenizer($options);
+        $registry = $tokenizer->run('Das ist ==nicht getrennt und das hat eine kunden--spezifische Trennung!');
+        $this->assertEquals($tReg, $registry);
+    }
+}


### PR DESCRIPTION
Allows one to add a tokenizer that will respect words that are

* either marked to be not hyphenated at all (prepend NoHyphenateString) 
* or already contain a (one!) custom hyphenation mark (CustomHyphen somewhere within the word)

The ```NoHyphenateString``` and the ```CustomHyphen``` can be set via the Options.