### PR TITLE
Refactor tokenizers

### DIFF
--- a/src/Tokenizer/AbstractTokenizer.php
+++ b/src/Tokenizer/AbstractTokenizer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Org\Heigl\Hyphenator\Tokenizer;
+
+abstract class AbstractTokenizer implements Tokenizer
+{
+    /**
+     * Split the given input into tokens.
+     *
+     * The input can be a string or a tokenRegistry. If the input is a
+     * TokenRegistry, each item will be tokenized.
+     *
+     * @param string|\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry $input The
+     * input to be tokenized
+     *
+     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
+     */
+    public function run($input)
+    {
+        if (! $input instanceof TokenRegistry) {
+            $wt = new WordToken($input);
+            $input = new TokenRegistry();
+            $input->add($wt);
+        }
+
+        // Clone the TokenRegistry to prevent iterating over newly inserted tokens
+        $registry = clone $input;
+
+        foreach ($input as $token) {
+            if (! $token instanceof WordToken) {
+                continue;
+            }
+            $newTokens = $this->tokenize($token->get());
+            if ($newTokens == array($token)) {
+                continue;
+            }
+            $registry->replace($token, $newTokens);
+        }
+
+        return $registry;
+    }
+
+    /**
+     * Split the given string into tokens.
+     *
+     * @param string $input The String to tokenize
+     *
+     * @return Token[]
+     */
+    abstract protected function tokenize($input);
+}

--- a/src/Tokenizer/CustomHyphenationTokenizer.php
+++ b/src/Tokenizer/CustomHyphenationTokenizer.php
@@ -36,7 +36,7 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
 use Org\Heigl\Hyphenator\Options;
 
 /**
- * Use Punktuation to split any input into tokens
+ * Use custom markers to split any input into tokens
  *
  * @category   Hyphenation
  * @package    Org_Heigl_Hyphenator
@@ -48,9 +48,8 @@ use Org\Heigl\Hyphenator\Options;
  * @link       http://github.com/heiglandreas/Hyphenator
  * @since      04.11.2011
  */
-class CustomHyphenationTokenizer implements Tokenizer
+class CustomHyphenationTokenizer extends AbstractTokenizer
 {
-
     private $options;
 
     public function __construct(Options $options)
@@ -59,53 +58,17 @@ class CustomHyphenationTokenizer implements Tokenizer
     }
 
     /**
-     * Split the given input into tokens using punktuation marks as splitter
+     * Split the given string into tokens using custom markers.
      *
-     * The input can be a string or a tokenRegistry. If the input is a
-     * TokenRegistry, each item will be tokenized.
-     *
-     * @param string|\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry $input The
-     * input to be tokenized
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
-     */
-    public function run($input)
-    {
-        if ($input instanceof TokenRegistry) {
-            // Tokenize a TokenRegistry
-            $f = clone($input);
-            foreach ($input as $token) {
-                if (! $token instanceof WordToken) {
-                    continue;
-                }
-                $newTokens = $this->tokenize($token->get());
-                $f->replace($token, $newTokens);
-            }
-
-            return $f ;
-        }
-
-        // Tokenize a simple string.
-        $array =  $this->tokenize($input);
-        $registry = new TokenRegistry();
-        foreach ($array as $item) {
-            $registry->add($item);
-        }
-
-        return $registry;
-    }
-
-    /**
-     * Split the given string into tokens using whitespace.
-     *
-     * Each whitespace is placed in a WhitespaceToken and everything else is
-     * placed in a WordToken-Object
+     * Each word starting with the "noHyphenateString" or containing the
+     * "customHyphen" marker is placed in a ExcludedWordToken and everything
+     * else is  placed in a WordToken-Object
      *
      * @param \string $input The String to tokenize
      *
-     * @return Token
+     * @return Token[]
      */
-    private function tokenize($input)
+    protected function tokenize($input)
     {
         $tokens = [];
 

--- a/src/Tokenizer/PunctuationTokenizer.php
+++ b/src/Tokenizer/PunctuationTokenizer.php
@@ -34,7 +34,7 @@
 namespace Org\Heigl\Hyphenator\Tokenizer;
 
 /**
- * Use Punktuation to split any input into tokens
+ * Use Punctuation to split any input into tokens
  *
  * @category   Hyphenation
  * @package    Org_Heigl_Hyphenator
@@ -46,9 +46,8 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
  * @link       http://github.com/heiglandreas/Hyphenator
  * @since      04.11.2011
  */
-class PunctuationTokenizer implements Tokenizer
+class PunctuationTokenizer extends AbstractTokenizer
 {
-
     /**
      * The tokens to be handled by this tokenizer as an array.
      *
@@ -96,56 +95,16 @@ class PunctuationTokenizer implements Tokenizer
     );
 
     /**
-     * Split the given input into tokens using punktuation marks as splitter
+     * Split the given input into tokens using punctuation marks as splitter.
      *
-     * The input can be a string or a tokenRegistry. If the input is a
-     * TokenRegistry, each item will be tokenized.
-     *
-     * @param string|\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry $input The
-     * input to be tokenized
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
-     */
-    public function run($input)
-    {
-        if ($input instanceof TokenRegistry) {
-            // Tokenize a TokenRegistry
-            $f = clone($input);
-            foreach ($input as $token) {
-                if (! $token instanceof WordToken) {
-                    continue;
-                }
-                $newTokens = $this->tokenize($token->get());
-                if ($newTokens == array($token)) {
-                    continue;
-                }
-                $f->replace($token, $newTokens);
-            }
-
-            return $f ;
-        }
-
-        // Tokenize a simple string.
-        $array =  $this->tokenize($input);
-        $registry = new TokenRegistry();
-        foreach ($array as $item) {
-            $registry->add($item);
-        }
-
-        return $registry;
-    }
-
-    /**
-     * Split the given string into tokens using whitespace.
-     *
-     * Each whitespace is placed in a WhitespaceToken and everything else is
+     * Each punctuation is placed in a NonWordToken and everything else is
      * placed in a WordToken-Object
      *
      * @param \string $input The String to tokenize
      *
-     * @return Token
+     * @return Token[]
      */
-    private function tokenize($input)
+    protected function tokenize($input)
     {
         $tokens = array();
         $signs = '\\' . implode('\\', $this->tokens);

--- a/src/Tokenizer/WhitespaceTokenizer.php
+++ b/src/Tokenizer/WhitespaceTokenizer.php
@@ -46,7 +46,7 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
  * @link       http://github.com/heiglandreas/Hyphenator
  * @since      04.11.2011
  */
-class WhitespaceTokenizer implements Tokenizer
+class WhitespaceTokenizer extends AbstractTokenizer
 {
     protected $whitespaces = array(
       '\s',           // white space
@@ -55,56 +55,16 @@ class WhitespaceTokenizer implements Tokenizer
     );
 
     /**
-     * Split the given input into tokens using whitespace as splitter
-     *
-     * The input can be a string or a tokenRegistry. If the input is a
-     * TokenRegistry, each item will be tokenized.
-     *
-     * @param string|\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry $input The
-     * input to be tokenized
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
-     */
-    public function run($input)
-    {
-        if ($input instanceof TokenRegistry) {
-            // Tokenize a TokenRegistry
-            $f = clone($input);
-            foreach ($input as $token) {
-                if (! $token instanceof WordToken) {
-                    continue;
-                }
-                $newTokens = $this->tokenize($token->get());
-                if ($newTokens == array($token)) {
-                    continue;
-                }
-                $f->replace($token, $newTokens);
-            }
-
-            return $f ;
-        }
-
-        // Tokenize a simple string.
-        $array =  $this->tokenize($input);
-        $registry = new TokenRegistry();
-        foreach ($array as $item) {
-            $registry->add($item);
-        }
-
-        return $registry;
-    }
-
-    /**
-     * Split the given string into tokens using whitespace.
+     * Split the given string into tokens using whitespace as splitter.
      *
      * Each whitespace is placed in a WhitespaceToken and everything else is
      * placed in a WordToken-Object
      *
      * @param string $input The String to tokenize
      *
-     * @return Token
+     * @return Token[]
      */
-    private function tokenize($input)
+    protected function tokenize($input)
     {
         $tokens = array();
         $splits = preg_split("/([".implode("", $this->whitespaces)."]+)/u", $input, -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Tokenizer/WhitespaceTokenizer.php
+++ b/src/Tokenizer/WhitespaceTokenizer.php
@@ -69,6 +69,7 @@ class WhitespaceTokenizer implements Tokenizer
     {
         if ($input instanceof TokenRegistry) {
             // Tokenize a TokenRegistry
+            $f = clone($input);
             foreach ($input as $token) {
                 if (! $token instanceof WordToken) {
                     continue;
@@ -77,10 +78,10 @@ class WhitespaceTokenizer implements Tokenizer
                 if ($newTokens == array($token)) {
                     continue;
                 }
-                $input->replace($token, $newTokens);
+                $f->replace($token, $newTokens);
             }
 
-            return $input ;
+            return $f ;
         }
 
         // Tokenize a simple string.

--- a/src/Tokenizer/WhitespaceTokenizer.php
+++ b/src/Tokenizer/WhitespaceTokenizer.php
@@ -66,15 +66,16 @@ class WhitespaceTokenizer extends AbstractTokenizer
      */
     protected function tokenize($input)
     {
+        $whitespaces = implode('', $this->whitespaces);
+        $splits = preg_split('/([' . $whitespaces . ']+)/u', $input, -1, PREG_SPLIT_DELIM_CAPTURE);
         $tokens = array();
-        $splits = preg_split("/([".implode("", $this->whitespaces)."]+)/u", $input, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         foreach ($splits as $split) {
             if ($split === '') {
                 $tokens[] = new EmptyToken($split);
                 continue;
             }
-            if (preg_match("/^[".implode("", $this->whitespaces)."]+$/um", $split)) {
+            if (preg_match('/^[' . $whitespaces . ']+$/um', $split)) {
                 $tokens[] = new WhitespaceToken($split);
                 continue;
             }

--- a/src/Tokenizer/XmlTokenizer.php
+++ b/src/Tokenizer/XmlTokenizer.php
@@ -46,59 +46,19 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
  * @link       http://github.com/heiglandreas/Hyphenator
  * @since      04.11.2011
  */
-class XmlTokenizer implements Tokenizer
+class XmlTokenizer extends AbstractTokenizer
 {
     /**
-     * Split the given input into tokens using Html-Elements as splitter
+     * Split the given input into tokens using XML-Elements as splitter.
      *
-     * The input can be a string or a tokenRegistry. If the input is a
-     * TokenRegistry, each item will be tokenized.
-     *
-     * @param string|\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry $input The
-     * input to be tokenized
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
-     */
-    public function run($input)
-    {
-        if ($input instanceof TokenRegistry) {
-            // Tokenize a TokenRegistry
-            $f = clone($input);
-            foreach ($input as $token) {
-                if (! $token instanceof WordToken) {
-                    continue;
-                }
-                $newTokens = $this->tokenize($token->get());
-                if ($newTokens == array($token)) {
-                    continue;
-                }
-                $f->replace($token, $newTokens);
-            }
-
-            return $f ;
-        }
-
-        // Tokenize a simple string.
-        $array =  $this->tokenize($input);
-        $registry = new TokenRegistry();
-        foreach ($array as $item) {
-            $registry->add($item);
-        }
-
-        return $registry;
-    }
-
-    /**
-     * Split the given string into tokens using whitespace.
-     *
-     * Each whitespace is placed in a WhitespaceToken and everything else is
+     * Each XML tag is placed in a NonWordToken and everything else is
      * placed in a WordToken-Object
      *
      * @param string $input The String to tokenize
      *
-     * @return Token
+     * @return Token[]
      */
-    private function tokenize($input)
+    protected function tokenize($input)
     {
         $tokens = array();
         $splits = preg_split("/(<\/?[^>]+\/?>)/u", $input, -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Tokenizer/XmlTokenizer.php
+++ b/src/Tokenizer/XmlTokenizer.php
@@ -63,6 +63,7 @@ class XmlTokenizer implements Tokenizer
     {
         if ($input instanceof TokenRegistry) {
             // Tokenize a TokenRegistry
+            $f = clone($input);
             foreach ($input as $token) {
                 if (! $token instanceof WordToken) {
                     continue;
@@ -71,10 +72,10 @@ class XmlTokenizer implements Tokenizer
                 if ($newTokens == array($token)) {
                     continue;
                 }
-                $input->replace($token, $newTokens);
+                $f->replace($token, $newTokens);
             }
 
-            return $input ;
+            return $f ;
         }
 
         // Tokenize a simple string.


### PR DESCRIPTION
The `run()` method is duplicated in every `Tokenizer` so I extracted it into an `AbstractTokenizer` that is inherited by the various implementations.

Another change is to implode the `whitespaces` property of the `WhitespaceTokenizer` outside the loop. It is unnecessary overhead to implode the whitespace in each iteration again and again.

I also tried to add some meaningful descriptions in the DocBlocks. It seems that they were pretty much copy-pasted before.