### PR TITLE
Allow own dictionaries

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -9,7 +9,7 @@ add the provided autoloader either using your own autoloader or by
 invoking the ``Hyphenators`` own autoloader
 
 ::
-    
+
     <?php
     require_once 'path/to/Org/Heigl/Hyphenator/Hyphenator.php';
     \Org\Heigl\Hyphenator\Hyphenator::registerAutoload()
@@ -18,7 +18,7 @@ Simple Example
 ==============
 
 ::
-    
+
     <?php
     use \Org\Heigl\Hyphenator as h;
     $hyphenator = h\Hyphenator::factory();
@@ -47,7 +47,7 @@ Invoke the ``Hyphenator`` manually
 ==================================
 
 ::
-    
+
     <?php
     use \Org\Heigl\Hyphenator as h;
     $o = new h\Options();
@@ -68,7 +68,7 @@ Get the hyphenation of a single word as array
 =============================================
 
 ::
-    
+
     <?php
     use \Org\Heigl\Hyphenator as h;
     $o = new h\Options();
@@ -100,3 +100,28 @@ Get the hyphenation of a single word as array
    reuse the once created instance.
    Reading the largest hyphenation-pattern-file takes up to one
    second on a 2.5GHz Intel Core2 Duo using 4GB RAM.
+
+Add your own dictionary rules to the hyphenator
+===============================================
+
+::
+    use \Org\Heigl\Hyphenator\Hyphenator;
+    use Org\Heigl\Hyphenator\Dictionary\Dictionary;
+
+    $hyphenator = new Hyphenator();
+    $dictionary = Dictionary::fromFile('/path/to/my/dictionary/file.ini');
+    $hyphenator->getDictionaries()->addDictionary($dictionary);
+
+This will add the hyphenation patterns in file `file.ini` as further patterns.
+
+.. note::
+
+  The patterns in file `file.ini` need to look like this: `@:[string]="[numerical pattern]"`
+  where `[string]` is the string that will be matched and `[numerical pattern]` describes the
+  hyphenation pattern in digits from 0 to 9 where odd numbers mark hyphenation positions and
+  even numbers mark positions where a hyphenation is forbidden. The higher the number the
+  later it will be respected. Higher numbers will overwrite lower numbers when the patterns
+  are merged. The pattern always consists of one number more than the number of characters
+  of the string. The first number marks the position before the first character of the string,
+  the second number marks the position between the first and the second character and so on until the
+  last number which marks the position after the last character.

--- a/src/Dictionary/Dictionary.php
+++ b/src/Dictionary/Dictionary.php
@@ -206,10 +206,11 @@ class Dictionary
         for ($i = 0; $i <= $strlen; $i ++) {
             for ($j = 2; $j <= ($strlen-$i); $j++) {
                 $substr = mb_substr($word, $i, $j);
-                if (! isset($this->dictionary[$substr])) {
+                $lowerSubstring = mb_strtolower($substr);
+                if (! isset($this->dictionary[$lowerSubstring])) {
                     continue;
                 }
-                $return[$substr] = $this->dictionary[$substr];
+                $return[$substr] = $this->dictionary[$lowerSubstring];
             }
         }
 

--- a/src/Dictionary/Dictionary.php
+++ b/src/Dictionary/Dictionary.php
@@ -225,7 +225,7 @@ class Dictionary
      *
      * @return \Org\Heigl\Hyphenator\Dictionary\Dictionary
      */
-    public function addPAttern($string, $pattern)
+    public function addPattern($string, $pattern)
     {
         $this->dictionary[$string] = $pattern;
 

--- a/src/Dictionary/Dictionary.php
+++ b/src/Dictionary/Dictionary.php
@@ -33,7 +33,10 @@
 
 namespace Org\Heigl\Hyphenator\Dictionary;
 
+use RuntimeException;
 use function mb_substr;
+use function parse_ini_file;
+use function str_replace;
 
 /**
  * This class provides a generic dictionary containing hyphenation-patterns
@@ -89,6 +92,29 @@ class Dictionary
         $dict->load($locale);
 
         return $dict;
+    }
+
+    public static function fromLocale($locale): Dictionary
+    {
+        $dictionary = new Dictionary();
+        $dictionary->load($locale);
+
+        return $dictionary;
+    }
+
+    public static function fromFile(string $file): Dictionary
+    {
+        if (! is_file($file)) {
+            throw new RuntimeException(sprintf("The file \"%s\" is not readable", $file));
+        }
+
+        $dictionary = new Dictionary();
+
+        foreach (parse_ini_file($file) as $key => $val) {
+            $dictionary->dictionary[str_replace('@:', '', $key)] = $val;
+        }
+
+        return $dictionary;
     }
 
     /**

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -425,9 +425,7 @@ final class Hyphenator
      */
     public function getPatternForToken(WordToken $token)
     {
-        foreach ($this->getDictionaries() as $dictionary) {
-            $token->addPattern($dictionary->getPatternsForWord($token->get()));
-        }
+        $token->addPattern($this->getDictionaries()->getHyphenationPatterns($token->get()));
 
         return $token;
     }

--- a/tests/HyphenatorFeatureTest.php
+++ b/tests/HyphenatorFeatureTest.php
@@ -105,6 +105,10 @@ class HyphenatorFeatureTest extends TestCase
         $h = new h\Hyphenator();
         $h->setOptions($o);
 
+        $h->getDictionaries()->add(h\Dictionary\Dictionary::fromFile(__DIR__ . '/share/de_DE.ini'));
+
+//        $h->getDictionaries()->getDictionaryWithKey(0)->addPattern('strategie', '9800000000');
+
         $this->assertEquals($expected, $h->hyphenate($word));
     }
 

--- a/tests/HyphenatorFeatureTest.php
+++ b/tests/HyphenatorFeatureTest.php
@@ -126,6 +126,7 @@ class HyphenatorFeatureTest extends TestCase
             ['urinstinkt ', 'de_DE', 'ur^in^stinkt ', h\Hyphenator::QUALITY_HIGHEST],
             ['Brücke ', 'de_DE', 'Brü^cke ', h\Hyphenator::QUALITY_NORMAL],
             ['Röcke ', 'de_DE', 'Rö^cke '],
+            ['Produktionsstrategie ', 'de_DE', 'Pro^duk^ti^ons^stra^te^gie '],
         ];
     }
 
@@ -156,7 +157,7 @@ class HyphenatorFeatureTest extends TestCase
             [
                 '<xml>Otto<br/>Aussichtsturm</html>',
                 'de_DE',
-                '<xml>Ot^to<br/>Aus^sicht^sturm</html>',
+                '<xml>Ot^to<br/>Aus^sicht^s^turm</html>',
                 h\Hyphenator::QUALITY_NORMAL
             ],
         ];

--- a/tests/share/de_DE.ini
+++ b/tests/share/de_DE.ini
@@ -1,0 +1,1 @@
+@:produktionsstrategie = "000000000009800000000"


### PR DESCRIPTION
This PR will fix multiple issues.

* Up to now hyphenation of words with capital letters was borked as not all patterns could be found due to the patterns all being lowercase.
* It allows easily and more intuitively to add own dictionaries to the hyphenator not based on locale but based on a file-path.