### PR TITLE
Add return types to iterator-implementations

### DIFF
--- a/src/Dictionary/DictionaryRegistry.php
+++ b/src/Dictionary/DictionaryRegistry.php
@@ -35,6 +35,7 @@ namespace Org\Heigl\Hyphenator\Dictionary;
 
 use Iterator;
 use Countable;
+use OutOfBoundsException;
 
 /**
  * This class provides a registry for storing multiple dictionaries
@@ -63,10 +64,8 @@ class DictionaryRegistry implements Iterator, Countable
      * Add an item to the registry.
      *
      * @param Dictionary $dict The Dictionary to add to the registry
-     *
-     * @return DictionaryRegistry
      */
-    public function add(Dictionary $dict)
+    public function add(Dictionary $dict): self
     {
         if (! in_array($dict, $this->registry)) {
             $this->registry[] = $dict;
@@ -79,10 +78,8 @@ class DictionaryRegistry implements Iterator, Countable
      * Get a dictionary entry by its key
      *
      * @param mixed $key The key to retrieve the Dictionary for
-     *
-     * @return Dictionary|null
      */
-    public function getDictionaryWithKey($key)
+    public function getDictionaryWithKey($key): ?Dictionary
     {
         if (array_key_exists($key, $this->registry)) {
             return $this->registry[$key];
@@ -110,9 +107,9 @@ class DictionaryRegistry implements Iterator, Countable
      *
      * @param string $word The word to get the patterns for.
      *
-     * @return array
+     * @return array<string>
      */
-    public function getHyphenationPatterns($word)
+    public function getHyphenationPatterns($word): array
     {
         $pattern = array(array());
         foreach ($this as $dictionary) {
@@ -123,13 +120,11 @@ class DictionaryRegistry implements Iterator, Countable
     }
 
     /**
-     * Implementation of \Iterator
+     * Implementation of Iterator
      *
-     * @see \Iterator::rewind()
-     *
-     * @return void
+     * @see Iterator::rewind()
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->registry);
     }
@@ -137,35 +132,44 @@ class DictionaryRegistry implements Iterator, Countable
     /**
      * Get the current object
      *
-     * @see \Iterator::current()
+     * @see Iterator::current()
      *
      * @return \Org\Heigl\Hyphenator\Dictionary\Dictionary
      */
-    public function current()
+    public function current(): Dictionary
     {
-        return current($this->registry);
+        $current = current($this->registry);
+        if (false === $current) {
+            throw new OutOfBoundsException('You requested a non-existent entry');
+        }
+
+        return $current;
     }
 
     /**
      * Get the current key
      *
-     * @see \Iterator::key()
+     * @see Iterator::key()
      *
      * @return mixed
      */
-    public function key()
+    public function key(): int
     {
-        return key($this->registry);
+        $key = key($this->registry);
+
+        if (null === $key) {
+            throw new OutOfBoundsException('You requested a non-existend key');
+        }
+
+        return $key;
     }
 
     /**
      * Get the number of items in the registry
      *
-     * @see \Countable::count()
-     *
-     * @return int
+     * @see Countable::count()
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -173,11 +177,9 @@ class DictionaryRegistry implements Iterator, Countable
     /**
      * Push the internal pointer forward one step
      *
-     * @see \Iterator::next()
-     *
-     * @return void
+     * @see Iterator::next()
      */
-    public function next()
+    public function next(): void
     {
         next($this->registry);
     }
@@ -185,16 +187,10 @@ class DictionaryRegistry implements Iterator, Countable
     /**
      * Check whether the current pointer is in a valid place
      *
-     * @see \Iterator::valid()
-     *
-     * @return boolean
+     * @see Iterator::valid()
      */
-    public function valid()
+    public function valid(): bool
     {
-        if (false === current($this->registry)) {
-            return false;
-        }
-
-        return true;
+        return false !== current($this->registry);
     }
 }

--- a/src/Filter/FilterRegistry.php
+++ b/src/Filter/FilterRegistry.php
@@ -37,6 +37,7 @@ namespace Org\Heigl\Hyphenator\Filter;
 use Countable;
 use Iterator;
 use Org\Heigl\Hyphenator\Tokenizer\TokenRegistry;
+use OutOfBoundsException;
 
 /**
  * This class provides a registry for storing multiple filters
@@ -66,10 +67,8 @@ class FilterRegistry implements Iterator, Countable
      *
      * @param Filter $filter The Filter
      * to be added
-     *
-     * @return FilterRegistry
      */
-    public function add(Filter $filter)
+    public function add(Filter $filter): self
     {
         if (! in_array($filter, $this->registry)) {
             $this->registry[] = $filter;
@@ -82,10 +81,8 @@ class FilterRegistry implements Iterator, Countable
      * Get a Filters entry by its key
      *
      * @param mixed $key The key to get the Filter for.
-     *
-     * @return Filter|null
      */
-    public function getFilterWithKey($key)
+    public function getFilterWithKey($key): ?Filter
     {
         if (array_key_exists($key, $this->registry)) {
             return $this->registry[$key];
@@ -96,10 +93,8 @@ class FilterRegistry implements Iterator, Countable
 
     /**
      * Cleanup the registry
-     *
-     * @return FilterRegistry
      */
-    public function cleanup()
+    public function cleanup(): self
     {
         $this->registry = array();
 
@@ -111,10 +106,8 @@ class FilterRegistry implements Iterator, Countable
      *
      * @param TokenRegistry $tokens The
      * Registry to filter
-     *
-     * @return TokenRegistry
      */
-    public function filter(TokenRegistry $tokens)
+    public function filter(TokenRegistry $tokens): TokenRegistry
     {
         foreach ($this as $filter) {
             $tokens = $filter->run($tokens);
@@ -143,10 +136,8 @@ class FilterRegistry implements Iterator, Countable
      * Implementation of Iterator
      *
      * @see Iterator::rewind()
-     *
-     * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->registry);
     }
@@ -155,12 +146,15 @@ class FilterRegistry implements Iterator, Countable
      * Get the current object
      *
      * @see Iterator::current()
-     *
-     * @return Filter
      */
-    public function current()
+    public function current(): Filter
     {
-        return current($this->registry);
+        $current = current($this->registry);
+        if (false === $current) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $current;
     }
 
     /**
@@ -170,19 +164,23 @@ class FilterRegistry implements Iterator, Countable
      *
      * @return mixed
      */
-    public function key()
+    public function key(): int
     {
-        return key($this->registry);
+        $key = key($this->registry);
+
+        if (null === $key) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $key;
     }
 
     /**
      * Get the number of items in the registry
      *
      * @see Countable::count()
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -191,10 +189,8 @@ class FilterRegistry implements Iterator, Countable
      * Push the internal pointer forward one step
      *
      * @see Iterator::next()
-     *
-     * @return void
      */
-    public function next()
+    public function next(): void
     {
         next($this->registry);
     }
@@ -203,15 +199,9 @@ class FilterRegistry implements Iterator, Countable
      * Check whether the current pointer is in a valid place
      *
      * @see Iterator::valid()
-     *
-     * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
-        if (false === current($this->registry)) {
-            return false;
-        }
-
-        return true;
+        return false !== current($this->registry);
     }
 }

--- a/src/Tokenizer/TokenRegistry.php
+++ b/src/Tokenizer/TokenRegistry.php
@@ -35,6 +35,7 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
 
 use Iterator;
 use Countable;
+use OutOfBoundsException;
 
 /**
  * This class provides a registry for storing Tokens
@@ -55,7 +56,7 @@ class TokenRegistry implements Iterator, Countable
     /**
      * Storage for the Tokens.
      *
-     * @var \Org\Heigl\Hyphenator\Tokenizer\Token[] $registry
+     * @var Token[] $registry
      */
     private $registry = array();
 
@@ -63,10 +64,8 @@ class TokenRegistry implements Iterator, Countable
      * Add an item to the registry
      *
      * @param \Org\Heigl\Hyphenator\Tokenizer\Token $token The token to add
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\TokenRegistry
      */
-    public function add(Token $token)
+    public function add(Token $token): self
     {
         $this->registry[] = $token;
 
@@ -81,10 +80,8 @@ class TokenRegistry implements Iterator, Countable
      *
      * @param Token   $oldToken  The token to be replaced
      * @param Token[] $newTokens The array of tokens replacing the old one
-     *
-     * @return TokenRegistry
      */
-    public function replace(Token $oldToken, array $newTokens)
+    public function replace(Token $oldToken, array $newTokens): self
     {
         // Get the current key of the element.
         $key = array_search($oldToken, $this->registry, true);
@@ -111,10 +108,8 @@ class TokenRegistry implements Iterator, Countable
      * Get a Token entry by its key
      *
      * @param mixed $key The key to get the token for
-     *
-     * @return Token|null
      */
-    public function getTokenWithKey($key)
+    public function getTokenWithKey($key): ?Token
     {
         if (array_key_exists($key, $this->registry)) {
             return $this->registry[$key];
@@ -126,11 +121,9 @@ class TokenRegistry implements Iterator, Countable
     /**
      * Implementation of \Iterator
      *
-     * @see \Iterator::rewind()
-     *
-     * @return void
+     * @see Iterator::rewind()
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->registry);
     }
@@ -138,35 +131,41 @@ class TokenRegistry implements Iterator, Countable
     /**
      * Get the current object
      *
-     * @see \Iterator::current()
-     *
-     * @return \Org\Heigl\Hyphenator\Tokenizer\Token
+     * @see Iterator::current()
      */
-    public function current()
+    public function current(): Token
     {
-        return current($this->registry);
+        $current = current($this->registry);
+
+        if (false === $current) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $current;
     }
 
     /**
      * Get the current key
      *
-     * @see \Iterator::key()
-     *
-     * @return mixed
+     * @see Iterator::key()
      */
-    public function key()
+    public function key(): int
     {
-        return key($this->registry);
+        $key = key($this->registry);
+
+        if (null === $key) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $key;
     }
 
     /**
      * Get the number of items in the registry
      *
-     * @see \Countable::count()
-     *
-     * @return int
+     * @see Countable::count()
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -174,11 +173,11 @@ class TokenRegistry implements Iterator, Countable
     /**
      * Push the internal pointer forward one step
      *
-     * @see \Iterator::next()
+     * @see Iterator::next()
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         next($this->registry);
     }
@@ -186,16 +185,12 @@ class TokenRegistry implements Iterator, Countable
     /**
      * Check whether the current pointer is in a valid place
      *
-     * @see \Iterator::valid()
+     * @see Iterator::valid()
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
-        if (false === current($this->registry)) {
-            return false;
-        }
-
-        return true;
+        return null !== key($this->registry);
     }
 }

--- a/src/Tokenizer/TokenizerRegistry.php
+++ b/src/Tokenizer/TokenizerRegistry.php
@@ -35,6 +35,7 @@ namespace Org\Heigl\Hyphenator\Tokenizer;
 
 use Countable;
 use Iterator;
+use OutOfBoundsException;
 
 /**
  * This class provides a registry for storing multiple Tokenizers
@@ -63,10 +64,8 @@ class TokenizerRegistry implements Iterator, Countable
      * Add an item to the registry
      *
      * @param Tokenizer $tokenizer The tokeniter to be added
-     *
-     * @return TokenizerRegistry
      */
-    public function add(Tokenizer $tokenizer)
+    public function add(Tokenizer $tokenizer): self
     {
         if (! in_array($tokenizer, $this->registry)) {
             $this->registry[] = $tokenizer;
@@ -79,10 +78,8 @@ class TokenizerRegistry implements Iterator, Countable
      * Get a dictionary entry by its key
      *
      * @param mixed $key The key to get the tokenizer for.
-     *
-     * @return Tokenizer|null
      */
-    public function getTokenizerWithKey($key)
+    public function getTokenizerWithKey($key): ?Tokenizer
     {
         if (array_key_exists($key, $this->registry)) {
             return $this->registry[$key];
@@ -93,10 +90,8 @@ class TokenizerRegistry implements Iterator, Countable
 
     /**
      * Cleanup the registry
-     *
-     * @return TokenizerRegistry
      */
-    public function cleanup()
+    public function cleanup(): self
     {
         $this->registry = array();
 
@@ -107,10 +102,8 @@ class TokenizerRegistry implements Iterator, Countable
      * Pass the given string through the given tokenizers
      *
      * @param string|TokenRegistry $string The String to be tokenized
-     *
-     * @return TokenRegistry
      */
-    public function tokenize($string)
+    public function tokenize($string): TokenRegistry
     {
         if (! $string instanceof TokenRegistry) {
             $wt = new WordToken($string);
@@ -128,10 +121,8 @@ class TokenizerRegistry implements Iterator, Countable
      * Implementation of Iterator
      *
      * @see Iterator::rewind()
-     *
-     * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->registry);
     }
@@ -140,34 +131,40 @@ class TokenizerRegistry implements Iterator, Countable
      * Get the current object
      *
      * @see Iterator::current()
-     *
-     * @return Tokenizer
      */
-    public function current()
+    public function current(): Tokenizer
     {
-        return current($this->registry);
+        $current = current($this->registry);
+
+        if (false === $current) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $current;
     }
 
     /**
      * Get the current key
      *
      * @see Iterator::key()
-     *
-     * @return mixed
      */
-    public function key()
+    public function key(): int
     {
-        return key($this->registry);
+        $key = key($this->registry);
+
+        if (null === $key) {
+            throw new OutOfBoundsException('You requested a non-existend entry');
+        }
+
+        return $key;
     }
 
     /**
      * Get the number of items in the registry
      *
      * @see Countable::count()
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -176,10 +173,8 @@ class TokenizerRegistry implements Iterator, Countable
      * Push the internal pointer forward one step
      *
      * @see Iterator::next()
-     *
-     * @return void
      */
-    public function next()
+    public function next(): void
     {
         next($this->registry);
     }
@@ -188,15 +183,9 @@ class TokenizerRegistry implements Iterator, Countable
      * Check whether the current pointer is in a valid place
      *
      * @see Iterator::valid()
-     *
-     * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
-        if (false === current($this->registry)) {
-            return false;
-        }
-
-        return true;
+        return null !== key($this->registry);
     }
 }

--- a/tests/Filter/NonstandardFilterTest.php
+++ b/tests/Filter/NonstandardFilterTest.php
@@ -93,7 +93,7 @@ class NonStandardFilterTest extends TestCase
         $tokenList = M::mock('\Org\Heigl\Hyphenator\Tokenizer\TokenRegistry');
         $tokenList->shouldReceive('rewind')->once();
         $tokenList->shouldReceive('valid')->twice()->andReturnValues(array(true, false));
-        $tokenList->shouldReceive('current')->once()->andReturn('foo');
+        $tokenList->shouldReceive('current')->once()->andReturn(new t\Token('foo'));
         $tokenList->shouldReceive('next')->once();
         $tokenList->shouldReceive('key')->andReturn(0);
 


### PR DESCRIPTION
This adds the correct return-types to the iterator- and countable-
implementations.

It also adds some simplifications and unifications to make the API more
easily to consume.