### PR TITLE
Add a .gitattributes file to trim down the generated archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.github export-ignore
+/dist export-ignore
+/doc export-ignore
+/docs export-ignore
+/tests export-ignore
+/tools export-ignore
+/.coveralls.yml export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/build.xml export-ignore
+/docblox.dist.xml export-ignore
+/index.php export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore
+/psalm.xml export-ignore


### PR DESCRIPTION
By default, composer downloads the zip archive generated by GitHub (using `git archive`). Excluding all the files that are not needed for using the library makes the archive smaller (and also the installed size of the package).